### PR TITLE
Implement firestore to allow ordering from menu functionality

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,3 +1,5 @@
 /build
 
 app/src/main/res/values/keys.xml
+
+google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,6 +111,9 @@ dependencies {
     implementation("com.google.android.gms:play-services-auth:21.3.0")
     implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
     implementation("androidx.credentials:credentials:1.5.0")
+
+    // Firestore for storing my current orders
+    implementation ("com.google.firebase:firebase-firestore-ktx")
 }
 kapt {
     correctErrorTypes = true

--- a/app/src/main/java/ie/setu/orderreceiver/data/entities/Order.kt
+++ b/app/src/main/java/ie/setu/orderreceiver/data/entities/Order.kt
@@ -1,0 +1,11 @@
+package ie.setu.orderreceiver.data.entities
+
+data class Order(
+    //java.lang.RuntimeException: Could not deserialize object. Class ie.setu.orderreceiver.data.entities.Order does not define a no-argument constructor.
+    val itemId: String = "",
+    val name: String = "",
+    val price: Double = 0.0,
+    val completed: Boolean = false,
+    val timestamp: Long = 0L,
+    val userId: String = ""
+)

--- a/app/src/main/java/ie/setu/orderreceiver/navigation/AppNavigator.kt
+++ b/app/src/main/java/ie/setu/orderreceiver/navigation/AppNavigator.kt
@@ -54,8 +54,10 @@ fun AppNavigator(
         }
         composable(Destinations.ORDERS.route) {
             ScreenWithBottomNavBar(navController = navController) {
+                val menuViewModel: MenuViewModel = hiltViewModel()
                 OrdersScreen(
-                    navController
+                    navController,
+                    menuViewModel
                 )
             }
         }

--- a/app/src/main/java/ie/setu/orderreceiver/ui/screens/Menu.kt
+++ b/app/src/main/java/ie/setu/orderreceiver/ui/screens/Menu.kt
@@ -1,7 +1,9 @@
 package ie.setu.orderreceiver.ui.screens
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,9 +16,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DismissValue
@@ -66,7 +68,7 @@ fun Menu(viewModel: MenuViewModel) {
     val menuItems by viewModel.menu.collectAsState()
     var selectedCategoryFilter by remember { mutableStateOf<Categories?>(null) }
     var showDialog by remember { mutableStateOf(false) }
-
+    val context = LocalContext.current
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -86,12 +88,14 @@ fun Menu(viewModel: MenuViewModel) {
                         viewModel.deleteMenuItem(menuItem)
                     }
 
-                    DismissValue.DismissedToEnd -> {
-                        // Add to orders
-                    }
-
                     else -> {}
                 }
+            }, onAddToOrder = {
+                viewModel.addToOrder(it, onAddToOrderSuccess = {
+                    Toast.makeText(context, R.string.order_success, Toast.LENGTH_SHORT).show()
+                }, onAddToOrderFail = {
+                    Toast.makeText(context, R.string.order_failed, Toast.LENGTH_SHORT).show()
+                })
             })
         }
 
@@ -133,6 +137,7 @@ fun Menu(viewModel: MenuViewModel) {
 @Composable
 fun MenuItemRow(
     menuItem: MenuItem,
+    onAddToOrder: (menuItem: MenuItem) -> Unit,
     onDismiss: (menuItem: MenuItem, dismissValue: DismissValue) -> Unit
 ) {
     val dismissState = rememberDismissState()
@@ -145,14 +150,7 @@ fun MenuItemRow(
         background = {
             val color = when (dismissState.targetValue) {
                 DismissValue.DismissedToStart -> Color.Red
-                DismissValue.DismissedToEnd -> Color.Green
                 else -> Color.Transparent
-            }
-
-            val icon = when (dismissState.targetValue) {
-                DismissValue.DismissedToStart -> Icons.Default.DeleteForever
-                DismissValue.DismissedToEnd -> Icons.Default.ShoppingCart
-                else -> null
             }
 
             val iconAlignment = when (dismissState.targetValue) {
@@ -166,18 +164,20 @@ fun MenuItemRow(
                     .background(color),
                 contentAlignment = iconAlignment
             ) {
-                icon?.let {
-                    Icon(
-                        imageVector = it,
-                        contentDescription = null,
-                        modifier = Modifier.padding(16.dp)
-                    )
-                }
+                Icon(
+                    imageVector = Icons.Default.DeleteForever,
+                    contentDescription = null,
+                    modifier = Modifier.padding(16.dp)
+                )
             }
         },
         dismissContent = {
             Card(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        onAddToOrder(menuItem)
+                    }
             ) {
                 Row(
                     modifier = Modifier
@@ -232,8 +232,7 @@ fun MenuItemRow(
             }
         }
     )
-    if (dismissState.targetValue == DismissValue.DismissedToStart ||
-        dismissState.targetValue == DismissValue.DismissedToEnd
+    if (dismissState.targetValue == DismissValue.DismissedToStart
     ) {
         onDismiss(menuItem, dismissState.currentValue)
     }
@@ -260,7 +259,7 @@ fun SwipeInstructionsPanel(menuLabel: String) {
                     modifier = Modifier.size(24.dp)
                 )
                 Icon(
-                    imageVector = Icons.Default.ArrowForward,
+                    imageVector = Icons.Default.TouchApp,
                     contentDescription = null,
                     modifier = Modifier.size(24.dp)
                 )

--- a/app/src/main/java/ie/setu/orderreceiver/ui/screens/OrdersScreen.kt
+++ b/app/src/main/java/ie/setu/orderreceiver/ui/screens/OrdersScreen.kt
@@ -1,10 +1,160 @@
 package ie.setu.orderreceiver.ui.screens
 
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessAlarms
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DeleteForever
+import androidx.compose.material3.Card
+import androidx.compose.material3.DismissValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SwipeToDismiss
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberDismissState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import ie.setu.orderreceiver.R
+import ie.setu.orderreceiver.data.entities.Order
+import ie.setu.orderreceiver.ui.viewmodels.MenuViewModel
 
 @Composable
-fun OrdersScreen(navController: NavController) {
-    Text(text = "THIS SCREEN WILL BE IMPLEMENTED AS PART OF ASSIGNMENT 2")
+fun OrdersScreen(navController: NavController, viewModel: MenuViewModel) {
+    val orders = viewModel.orders.collectAsState().value
+    LaunchedEffect(Unit) {
+        viewModel.loadOrders() // crashing in vm attempt to load here to give firestore time to init
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(16.dp)
+    ) {
+        item {
+            OrderPageInstructionsPanel()
+        }
+        items(orders) { order ->
+            OrderItemRow(
+                order = order,
+                onDelete = {
+                    viewModel.deleteOrder(order.itemId) {
+                        Toast.makeText(navController.context, R.string.order_deleted, Toast.LENGTH_SHORT).show()
+                        viewModel.loadOrders()
+                    }
+                },
+                onUpdateStatus = {
+                    viewModel.updateOrderStatus(order.itemId)
+                }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrderItemRow(
+    order: Order,
+    onDelete: () -> Unit,
+    onUpdateStatus: () -> Unit
+) {
+    val dismissState = rememberDismissState()
+    LaunchedEffect(dismissState.targetValue) {
+        if (dismissState.targetValue == DismissValue.DismissedToStart) {
+            onDelete()
+        }
+    }
+    SwipeToDismiss(
+        state = dismissState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        background = {
+            val color = if (dismissState.targetValue == DismissValue.DismissedToStart) Color.Red else Color.Transparent
+            val icon = if (dismissState.targetValue == DismissValue.DismissedToStart) Icons.Default.DeleteForever else null
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                icon?.let {
+                    Icon(imageVector = it, contentDescription = null, modifier = Modifier.padding(16.dp))
+                }
+            }
+        },
+        dismissContent = {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                        .clickable { onUpdateStatus() }
+                ) {
+                    AsyncImage(
+                        model = "placeholder", // Placeholder for now until i implement cloud firestore
+                        contentDescription = order.name,
+                        modifier = Modifier
+                            .size(100.dp)
+                            .align(Alignment.CenterVertically),
+                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.CenterVertically),
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(order.name, fontWeight = FontWeight.Bold)
+                        Text("Price: \$${order.price}")
+                        Icon(
+                            imageVector = if (order.completed) Icons.Default.Check else Icons.Default.AccessAlarms,
+                            contentDescription = null
+                        )
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun OrderPageInstructionsPanel() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        shape = RectangleShape
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Tap to update order status, swipe to delete from firestore",
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
 }

--- a/app/src/main/java/ie/setu/orderreceiver/ui/viewmodels/MenuViewModel.kt
+++ b/app/src/main/java/ie/setu/orderreceiver/ui/viewmodels/MenuViewModel.kt
@@ -1,10 +1,14 @@
 package ie.setu.orderreceiver.ui.viewmodels
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import ie.setu.orderreceiver.data.dao.MenuDao
 import ie.setu.orderreceiver.data.entities.MenuItem
+import ie.setu.orderreceiver.data.entities.Order
 import ie.setu.orderreceiver.utils.Categories
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,9 +23,15 @@ class MenuViewModel @Inject constructor(private val dao: MenuDao) : ViewModel() 
     private val _menu = MutableStateFlow<List<MenuItem>>(emptyList())
     val menu: StateFlow<List<MenuItem>> get() = _menu.asStateFlow()
 
+    // Orders (Assignment 2)
+    private val _orders = MutableStateFlow<List<Order>>(emptyList())
+    val orders: StateFlow<List<Order>> get() = _orders.asStateFlow()
+
     init {
         loadMenuItems()
     }
+
+    private val fireStore = FirebaseFirestore.getInstance()
 
     fun loadMenuItems() {
         viewModelScope.launch(Dispatchers.IO) {
@@ -51,5 +61,75 @@ class MenuViewModel @Inject constructor(private val dao: MenuDao) : ViewModel() 
                 _menu.value = menuItems
             }
         }
+    }
+
+    //Firestore (Assignment 2)
+
+    //https://firebase.google.com/docs/firestore/manage-data/add-data#kotlin_1
+    fun addToOrder(menuItem: MenuItem, onAddToOrderSuccess: () -> Unit, onAddToOrderFail: () -> Unit) {
+        val order = Order(
+            itemId = menuItem.itemId,
+            name = menuItem.name,
+            price = menuItem.price,
+            userId = FirebaseAuth.getInstance().currentUser!!.uid
+        )
+        //https://stackoverflow.com/questions/73718391/how-to-add-data-to-the-firebase-firestore-by-generating-different-document-id-af
+        fireStore.collection("orders")
+            .document(order.itemId)
+            .set(order)
+            .addOnSuccessListener {
+                Log.d("MenuViewModel", "Order successfully uploaded!")
+                onAddToOrderSuccess()
+            }
+            .addOnFailureListener { e ->
+                Log.w("MenuViewModel", "Error uploading order", e)
+                onAddToOrderFail()
+            }
+    }
+
+    fun loadOrders() {
+        Log.d("MenuViewModel", "loadOrders() called.")
+        fireStore.collection("orders")
+            .whereEqualTo("userId", FirebaseAuth.getInstance().currentUser!!.uid)
+            .addSnapshotListener { snapshot, exception ->
+                if (exception != null) {
+                    Log.w("MenuViewModel", "Error loading orders", exception)
+                    return@addSnapshotListener
+                }
+
+                val orderList = snapshot?.documents?.map { document ->
+                    document.toObject(Order::class.java) ?: Order(
+                        itemId = "",
+                        name = "",
+                        price = 0.0,
+                        userId = FirebaseAuth.getInstance().currentUser!!.uid
+                    )
+                } ?: emptyList()
+
+                _orders.value = orderList
+            }
+    }
+
+    fun deleteOrder(orderId: String, onSuccess: () -> Unit) {
+        fireStore.collection("orders").document(orderId)
+            .delete()
+            .addOnSuccessListener {
+                Log.d("MenuViewModel", "Order $orderId deleted successfully.")
+                onSuccess()
+            }
+            .addOnFailureListener { e ->
+                Log.e("MenuViewModel", "Error deleting order $orderId", e)
+            }
+    }
+
+    fun updateOrderStatus(orderId: String) {
+        fireStore.collection("orders").document(orderId)
+            .update("completed", true)
+            .addOnSuccessListener {
+                Log.d("MenuViewModel", "Order status updated.")
+            }
+            .addOnFailureListener { e ->
+                Log.e("MenuViewModel", "Error updating order status", e)
+            }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,10 @@
     <string name="register_failed">Registration has failed! Please try again!</string>
     <string name="account_already">Already have an account? Log in</string>
     <string name="login_failed">Login failed please check your username and password!</string>
+    <string name="order_success">Item has been ordered and sent to Firestore! Go to the orders page to see it!</string>
+    <string name="order_failed">Item has NOT been ordered or sent to Firestore successfully</string>
+    <string name="order_deleted">Order deleted from Firestore successfully!</string>
+    <string name="order_deleted_failed">Order NOT deleted from Firestore successfully!</string>
     <string name="menu">Menu</string>
     <string name="orders">Orders</string>
     <string name="add_to_menu">Add To Menu</string>


### PR DESCRIPTION
Added google firestore to store orders in firestore. Menu items are still stored in room but when clicked are added to orders which is firestore. These orders can be swiped to be deleted or tapped to be updated i.e completed. Closes #3 